### PR TITLE
Fix deprecation in brew formula

### DIFF
--- a/tubekit.rb
+++ b/tubekit.rb
@@ -4,6 +4,8 @@ class Tubekit < Formula
   url "https://github.com/reconquest/tubekit/releases/download/v3/tubekit_3_Darwin_x86_64.tar.gz"
   sha256 "b966e7b014e0d16e22f0d15dbd7c80a084160c6851bf7ad767d0085ac3ac10d1"
 
+  depends_on "kubernetes-cli"
+
   def install
     bin.install "tubectl"
   end

--- a/tubekit.rb
+++ b/tubekit.rb
@@ -4,10 +4,6 @@ class Tubekit < Formula
   url "https://github.com/reconquest/tubekit/releases/download/v3/tubekit_3_Darwin_x86_64.tar.gz"
   sha256 "b966e7b014e0d16e22f0d15dbd7c80a084160c6851bf7ad767d0085ac3ac10d1"
 
-  bottle :unneeded
-
-  depends_on "kubernetes-cli"
-
   def install
     bin.install "tubectl"
   end


### PR DESCRIPTION
Remove deprecated `bottle :unneeded` from formula.

This PR supersedes #13 to restore `kubectl` dependency.