### PR TITLE
Add basic nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The package is always available in AUR:
 
 Packages can be found on [releases page](https://github.com/reconquest/tubekit/releases).
 
+#### nix (on Linux or macOS) / nixOS
+
+With flakes support:
+
+```
+$ nix profile install github:reconquest/tubekit
+```
+
 #### macOS
 
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1642609835,
+        "narHash": "sha256-ZwJnV4mdis28u5vH240ec2mrApuEJYJekn23qlTwJ8c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "77aa71f66fd05d9e7b7d1c084865d703a8008ab7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "kubectl alternative with quick context switching, kubectl on steroids";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+
+  outputs = { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          tubectl = pkgs.buildGoModule {
+            pname = "tubectl";
+            inherit version;
+            # In 'nix develop', we don't need a copy of the source tree
+            # in the Nix store.
+            src = ./.;
+
+            # This hash locks the dependencies of this package. It is
+            # necessary because of how Go requires network access to resolve
+            # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
+            # details. Normally one can build with a fake sha256 and rely on native Go
+            # mechanisms to tell you what the hash should be or determine what
+            # it should be "out-of-band" with other tooling (eg. gomod2nix).
+            # To begin with it is recommended to set this, but one must
+            # remeber to bump this hash when your dependencies change.
+            #vendorSha256 = pkgs.lib.fakeSha256;
+
+            vendorSha256 = "sha256-VIQunsdcHovw6jah8V39KxQ+kOk5mAJRDsM4FxT4wME=";
+          };
+        });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage = forAllSystems (system: self.packages.${system}.tubectl);
+    };
+}


### PR DESCRIPTION
This adds support for the nix build system / package manager / OS.

The branch can be verified functional via installing `nix profile install github:farcaller/tubekit`.