### PR TITLE
Pass the first verb before the flags to support krew plugins

### DIFF
--- a/cmd/tubectl/main.go
+++ b/cmd/tubectl/main.go
@@ -156,6 +156,11 @@ func main() {
 func syscallExec(client string, params *Params) {
 	args := []string{client}
 
+	if len(params.Args) > 0 {
+		args = append(args, params.Args[0])
+		params.Args = params.Args[1:]
+	}
+
 	if arg := buildArgKubeconfig(params.Kubeconfig); arg != "" {
 		args = append(args, arg)
 	}


### PR DESCRIPTION
For simple command invocations, pass the first verb before the flags. This fixes the `Error: flags cannot be placed before plugin name` error with krew plugins.